### PR TITLE
ci: install ruby 3.3.0-preview2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       image: ubuntu-2204:2023.10.1
     steps:
       - run: sudo apt update
-      - run: sudo apt install libssl3
+      - run: sudo apt install libssl-dev
       - ruby/install:
           version: "3.3.0-preview2"
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,11 @@ jobs:
       image: ubuntu-2204:2023.10.1
     steps:
       - run: sudo apt update
-      - run: DEBIAN_FRONTEND=noninteractive sudo apt install openssl
+      - run: DEBIAN_FRONTEND=noninteractive sudo apt install rbenv
       # ruby/install - version: "3.3.0-preview2"
       - run: |
-          gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-          curl -sSL "https://get.rvm.io" | bash -s stable
-      - run: rvm install 3.3.0-preview2
-      - run: |
-          rvm use 3.3.0-preview2
-          RUBY_PATH="$(rvm 3.3.0-preview2 1> /dev/null 2> /dev/null && rvm env --path)"
-          printf '%s\n' "source $RUBY_PATH" >> "$BASH_ENV"
+          rbenv init
+      - run: rbenv install 3.3.0-preview2
       - checkout
       # ruby/install-deps
       - run: bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - run: DEBIAN_FRONTEND=noninteractive sudo apt install openssl
       # ruby/install - version: "3.3.0-preview2"
       - run: |
+          gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
           curl -sSL "https://get.rvm.io" | bash -s stable
       - run: rvm install 3.3.0-preview2
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2.1
+orbs:
+  browser-tools: circleci/ruby@2.0.1
+jobs:
+  build:
+    machine:
+      image: ubuntu-2204:2023.10.1
+    steps:
+      - ruby/install:
+          version: "3.3.0-preview2"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run: DEBIAN_FRONTEND=noninteractive sudo apt install rbenv
       # ruby/install - version: "3.3.0-preview2"
       - run: |
-          rbenv init
+          eval "$(rbenv init -)"
       - run: rbenv install 3.3.0-preview2
       - checkout
       # ruby/install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,3 +8,4 @@ jobs:
     steps:
       - ruby/install:
           version: "3.3.0-preview2"
+      - ruby/install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ jobs:
       - run: sudo apt update
       - run: DEBIAN_FRONTEND=noninteractive sudo apt install openssl
       # ruby/install - version: "3.3.0-preview2"
+      - run: |
+          curl -sSL "https://get.rvm.io" | bash -s stable
       - run: rvm install 3.3.0-preview2
       - run: |
           rvm use 3.3.0-preview2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       image: ubuntu-2204:2023.10.1
     steps:
       - run: sudo apt update
-      - run: DEBIAN_FRONTEND=noninteractive sudo apt install libssl-dev
+      - run: DEBIAN_FRONTEND=noninteractive sudo apt install openssl
       - ruby/install:
           version: "3.3.0-preview2"
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,11 @@ jobs:
     steps:
       - run: sudo apt update
       - run: DEBIAN_FRONTEND=noninteractive sudo apt install openssl
-      - ruby/install:
-          version: "3.3.0-preview2"
+      # ruby/install - version: "3.3.0-preview2"
+      - run: rvm install 3.3.0-preview2
+      - run: |
+          rvm use 3.3.0-preview2
+          RUBY_PATH="$(rvm 3.3.0-preview2 1> /dev/null 2> /dev/null && rvm env --path)"
+          printf '%s\n' "source $RUBY_PATH" >> "$BASH_ENV"
       - checkout
       - ruby/install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       image: ubuntu-2204:2023.10.1
     steps:
       - run: sudo apt update
-      - run: sudo apt install libssl-dev
+      - run: DEBIAN_FRONTEND=noninteractive sudo apt install libssl-dev
       - ruby/install:
           version: "3.3.0-preview2"
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/ruby@2.0.1
+  ruby: circleci/ruby@2.0.1
 jobs:
   build:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,5 @@ jobs:
           RUBY_PATH="$(rvm 3.3.0-preview2 1> /dev/null 2> /dev/null && rvm env --path)"
           printf '%s\n' "source $RUBY_PATH" >> "$BASH_ENV"
       - checkout
-      - ruby/install-deps
+      # ruby/install-deps
+      - run: bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
     machine:
       image: ubuntu-2204:2023.10.1
     steps:
+      - run: sudo apt update
+      - run: sudo apt install libssl3
       - ruby/install:
           version: "3.3.0-preview2"
+      - checkout
       - ruby/install-deps

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "nokogiri"


### PR DESCRIPTION
We cannot install Ruby 3.3.0-preview2 on Linux VM machine (image: ubuntu-2204:2023.10.1) with circleci/ruby orb 2.0.1.